### PR TITLE
Ensure analytics helpers are loaded

### DIFF
--- a/includes/handlers.php
+++ b/includes/handlers.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/analytics.php';
+
 function handle_logs_ajax(PDO $pdo): void
 {
   rl_hit('logs', 120);


### PR DESCRIPTION
## Summary
- load the analytics helper functions whenever the shared request handlers are included to avoid runtime failures

## Testing
- php -l includes/handlers.php

------
https://chatgpt.com/codex/tasks/task_e_68cbadf69100832a827d7125aad70e65