### PR TITLE
Destroy existing dashboard charts before reinitialising

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -8,6 +8,13 @@
   const monthlyCanvas = document.getElementById('monthlyOverview');
   if (monthlyCanvas) {
     const ctx = monthlyCanvas.getContext('2d');
+    const existingChart = typeof Chart.getChart === 'function'
+      ? Chart.getChart(monthlyCanvas)
+      : null;
+    if (existingChart) {
+      existingChart.destroy();
+    }
+
     new Chart(ctx, {
       type: 'line',
       data: {
@@ -46,6 +53,13 @@
   const deviceCanvas = document.getElementById('deviceUsage');
   if (deviceCanvas) {
     const ctx = deviceCanvas.getContext('2d');
+    const existingChart = typeof Chart.getChart === 'function'
+      ? Chart.getChart(deviceCanvas)
+      : null;
+    if (existingChart) {
+      existingChart.destroy();
+    }
+
     new Chart(ctx, {
       type: 'pie',
       data: {


### PR DESCRIPTION
## Summary
- destroy any existing dashboard charts before instantiating new Chart.js graphs
- guard Chart.getChart usage to avoid duplicate line and pie charts when the dashboard script re-runs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbbca70230832a8d515af50abbd9e7