### PR TITLE
Fix dashboard device query

### DIFF
--- a/index.php
+++ b/index.php
@@ -75,7 +75,7 @@ try {
   ];
 
   $deviceStmt = $pdo->prepare(
-    'SELECT user_agent, device_type
+    'SELECT user_agent
        FROM page_access_logs
       WHERE accessed_at >= :start AND accessed_at < :end'
   );


### PR DESCRIPTION
## Summary
- remove selection of the non-existent device_type column when collecting device usage stats on the dashboard

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cbcdb26af4832aacb6d0518099c4fa