### PR TITLE
Add Chart.js dashboards to home overview

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -51,3 +51,53 @@
 .stat-card .growth {
     font-size: 14px;
 }
+
+.chart-section .chart-card {
+    background: #fff;
+    border-radius: 12px;
+    padding: 20px 22px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    border: 1px solid #eee;
+    border-top: 4px solid #d01f28;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.chart-header h5 {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1f1f1f;
+}
+
+.chart-subtitle {
+    font-size: 13px;
+    color: #6c757d;
+}
+
+.chart-wrapper {
+    position: relative;
+    flex: 1 1 auto;
+    min-height: 320px;
+}
+
+.chart-wrapper canvas {
+    width: 100% !important;
+    height: 100% !important;
+}
+
+@media (max-width: 1199.98px) {
+    .stat-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 767.98px) {
+    .stat-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .chart-wrapper {
+        min-height: 260px;
+    }
+}

--- a/includes/render.php
+++ b/includes/render.php
@@ -64,12 +64,16 @@ function render_sidebar(string $active): void
 
 
 
-function render_footer(bool $includePlotly = false): void
+function render_footer(bool $includePlotly = false, bool $includeChartJs = false): void
 {
   echo '<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>';
 
   if ($includePlotly) {
     echo "\n<script src=\"https://cdn.plot.ly/plotly-2.29.1.min.js\"></script>";
+  }
+
+  if ($includeChartJs) {
+    echo "\n<script src=\"https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js\"></script>";
   }
 
 

--- a/index.php
+++ b/index.php
@@ -151,10 +151,145 @@ render_sidebar('home');
       </div>
     </section>
 
+    <section class="row g-4 chart-section">
+      <div class="col-12 col-lg-8">
+        <div class="chart-card h-100">
+          <div class="chart-header">
+            <h5 class="mb-1">Monthly page access trend</h5>
+            <p class="chart-subtitle mb-0">Showing the last six months of activity.</p>
+          </div>
+          <div class="chart-wrapper">
+            <canvas id="monthlyTrendChart"></canvas>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-lg-4">
+        <div class="chart-card h-100">
+          <div class="chart-header">
+            <h5 class="mb-1">Device distribution</h5>
+            <p class="chart-subtitle mb-0">Breakdown of traffic sources.</p>
+          </div>
+          <div class="chart-wrapper">
+            <canvas id="deviceBreakdownChart"></canvas>
+          </div>
+        </div>
+      </div>
+    </section>
+
   <?php endif; ?>
 </main>
 
 <?php
 echo '</div>';
 echo '</div>';
-render_footer();
+?>
+
+<?php if (!$error): ?>
+  <script>
+    window.addEventListener('load', () => {
+      if (!window.Chart) {
+        console.warn('Chart.js failed to load.');
+        return;
+      }
+
+      const monthlyLabels = <?= json_encode($monthlyLabels, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
+      const monthlyCounts = <?= json_encode($monthlyCounts, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
+      const deviceLabels = <?= json_encode($deviceChartLabels, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
+      const deviceCounts = <?= json_encode($deviceChartCounts, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
+
+      const primaryColor = '#d01f28';
+      const accentPalette = ['#d01f28', '#e14a51', '#e76c72', '#ed8f93', '#f3b1b4'];
+
+      const monthlyCanvas = document.getElementById('monthlyTrendChart');
+      if (monthlyCanvas) {
+        const ctx = monthlyCanvas.getContext('2d');
+        new window.Chart(ctx, {
+          type: 'line',
+          data: {
+            labels: monthlyLabels,
+            datasets: [{
+              label: 'Page accesses',
+              data: monthlyCounts,
+              borderColor: primaryColor,
+              backgroundColor: 'rgba(208, 31, 40, 0.15)',
+              pointBackgroundColor: primaryColor,
+              pointBorderWidth: 2,
+              tension: 0.35,
+              fill: true,
+              borderWidth: 3
+            }]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                backgroundColor: '#1f1f1f',
+                titleColor: '#ffffff',
+                bodyColor: '#ffffff',
+                padding: 12,
+                borderColor: 'rgba(255, 255, 255, 0.15)',
+                borderWidth: 1
+              }
+            },
+            scales: {
+              x: {
+                ticks: { color: '#4b4b4b' },
+                grid: { color: 'rgba(208, 31, 40, 0.08)', drawBorder: false }
+              },
+              y: {
+                beginAtZero: true,
+                ticks: { color: '#4b4b4b' },
+                grid: { color: 'rgba(208, 31, 40, 0.05)', drawBorder: false }
+              }
+            }
+          }
+        });
+      }
+
+      const deviceCanvas = document.getElementById('deviceBreakdownChart');
+      if (deviceCanvas) {
+        const ctx = deviceCanvas.getContext('2d');
+        const colors = deviceLabels.map((_, index) => accentPalette[index % accentPalette.length]);
+        new window.Chart(ctx, {
+          type: 'doughnut',
+          data: {
+            labels: deviceLabels,
+            datasets: [{
+              data: deviceCounts,
+              backgroundColor: colors,
+              borderColor: '#ffffff',
+              borderWidth: 2,
+              hoverOffset: 6
+            }]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            cutout: '58%',
+            plugins: {
+              legend: {
+                position: 'bottom',
+                labels: {
+                  color: '#4b4b4b',
+                  usePointStyle: true,
+                  pointStyle: 'circle'
+                }
+              },
+              tooltip: {
+                backgroundColor: '#1f1f1f',
+                titleColor: '#ffffff',
+                bodyColor: '#ffffff',
+                padding: 12
+              }
+            }
+          }
+        });
+      }
+    });
+  </script>
+<?php endif; ?>
+
+<?php
+render_footer(false, true);


### PR DESCRIPTION
## Summary
- integrate Chart.js visualizations into the dashboard to show monthly trends and device distribution in the #d01f28 theme
- allow the shared footer renderer to optionally include the Chart.js CDN script
- add responsive styling for the new chart cards alongside the existing stat grid

## Testing
- php -l index.php
- php -l includes/render.php

------
https://chatgpt.com/codex/tasks/task_e_68cbcf4673d4832aab0560ab5daac9c7